### PR TITLE
docs(readme): fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ wildfire.vim, all without the need to set up intricate text objects.
 
 However, since treesitter relies solely on AST for incremental
 selection, it tends to be overly **aggressive** for surrounds. In such
-case, I havt to revert to using text objects for selection, which is
+case, I have to revert to using text objects for selection, which is
 annoyed and tripped me up in practical use.
 
 On the other hand, treesitter doesn’t support the

--- a/README.qmd
+++ b/README.qmd
@@ -26,7 +26,7 @@ treesitter.
 
 I've found that treesitter's [`incremental_selection`](https://www.reddit.com/r/neovim/comments/r10llx/the_most_amazing_builtin_feature_nobody_ever/) is particularly handy for text selection. It often allows for selecting the desired text with fewer keystrokes compared to a well-configured wildfire.vim, all without the need to set up intricate text objects. 
 
-However, since treesitter relies solely on AST for incremental selection, it tends to be overly **aggressive** for surrounds. In such case, I havt to revert to using text objects for selection, which is annoyed and tripped me up in practical use. 
+However, since treesitter relies solely on AST for incremental selection, it tends to be overly **aggressive** for surrounds. In such case, I have to revert to using text objects for selection, which is annoyed and tripped me up in practical use. 
 
 On the other hand, treesitter doesn't support the `count prefix(vim.v.count)`, which can make it somewhat cumbersome when dealing with longer ranges. Its implementation is also a bit buggy, as you might select an area within the same range(see below).
 


### PR DESCRIPTION
Correct "I havt" -> "I have".

Great that you are using quarto, btw!