### PR TITLE
Migrate from deprecated nvim-treesitter.ts_utils to built-in APIs (main branch compatibility)

### DIFF
--- a/lua/wildfire/init.lua
+++ b/lua/wildfire/init.lua
@@ -156,7 +156,9 @@ local function select_incremental(get_parent)
             node = parent
             local nsrow, nscol, nerow, necol = vim.treesitter.get_node_range(node)
             -- Convert 0-based to 1-based indexing to match vim coordinates
-            nsrow, nscol, nerow, necol = nsrow + 1, nscol + 1, nerow + 1, necol + 1
+            -- Note: treesitter end_col is exclusive, but vim coordinates are inclusive
+            nsrow, nscol, nerow, necol = nsrow + 1, nscol + 1, nerow + 1, necol
+            -- necol: 0-based exclusive == 1-based inclusive, so no +1 needed
 
             local larger_range = utils.range_larger({ nsrow, nscol, nerow, necol }, { csrow, cscol, cerow, cecol })
 

--- a/lua/wildfire/init.lua
+++ b/lua/wildfire/init.lua
@@ -1,7 +1,6 @@
 local api = vim.api
 
 local keymap = vim.keymap
-local parsers = require("nvim-treesitter.parsers")
 local utils = require("wildfire.utils")
 
 local M = {}
@@ -29,7 +28,24 @@ local count = 1
 function M.unsurround_coordinates(node_or_range, buf)
     -- local lines = vim.split(s, "\n")
     local srow, scol, erow, ecol = utils.get_range(node_or_range)
-    local lines = vim.api.nvim_buf_get_text(buf, srow - 1, scol - 1, erow - 1, ecol, {})
+
+    -- Validate buffer bounds to prevent index out of bounds error
+    local line_count = vim.api.nvim_buf_line_count(buf)
+    if srow < 1 or erow > line_count or srow > erow then
+        return false, { srow, scol, erow, ecol }
+    end
+
+    -- Validate column bounds for the specific lines
+    if scol < 1 or ecol < 0 then
+        return false, { srow, scol, erow, ecol }
+    end
+
+    -- Use pcall to safely get text, handle any edge cases
+    local ok, lines = pcall(vim.api.nvim_buf_get_text, buf, srow - 1, scol - 1, erow - 1, ecol, {})
+    if not ok or not lines or #lines == 0 then
+        return false, { srow, scol, erow, ecol }
+    end
+
     local node_text = table.concat(lines, "\n")
     local match_brackets = nil
     for _, pair in ipairs(M.options.surrounds) do
@@ -103,6 +119,15 @@ function M.init_selection()
     count = vim.v.count1
     local node = vim.treesitter.get_node()
     if not node then
+        -- No treesitter node available, try to handle gracefully
+        -- Check if treesitter is available for this filetype
+        local buf = api.nvim_get_current_buf()
+        local ok, parser = pcall(vim.treesitter.get_parser, buf)
+        if not ok or not parser then
+            -- No parser available for this filetype
+            vim.notify("Wildfire: No treesitter parser available for this filetype", vim.log.levels.WARN)
+            return
+        end
         return
     end
     init_by_node(node)
@@ -133,9 +158,21 @@ local function select_incremental(get_parent)
 
         -- Initialize incremental selection with current selection
         if not nodes or #nodes == 0 then
-            local root = parsers.get_parser():parse()[1]:root()
+            -- Use native vim.treesitter API to get the parser
+            local ok, parser = pcall(vim.treesitter.get_parser, buf)
+            if not ok or not parser then
+                -- No parser available for this filetype, fallback to visual selection
+                return
+            end
+            local tree = parser:parse()[1]
+            if not tree then
+                return
+            end
+            local root = tree:root()
             local node = root:named_descendant_for_range(csrow - 1, cscol - 1, cerow - 1, cecol)
-            update_selection_by_node(node)
+            if node then
+                update_selection_by_node(node)
+            end
             return
         end
 
@@ -146,7 +183,17 @@ local function select_incremental(get_parent)
             if not parent or parent == node then
                 -- Keep searching in the main tree
                 -- TODO: we should search on the parent tree of the current node.
-                local root = parsers.get_parser():parse()[1]:root()
+                local ok, parser = pcall(vim.treesitter.get_parser, buf)
+                if not ok or not parser then
+                    utils.update_selection(buf, node)
+                    return
+                end
+                local tree = parser:parse()[1]
+                if not tree then
+                    utils.update_selection(buf, node)
+                    return
+                end
+                local root = tree:root()
                 parent = root:named_descendant_for_range(csrow - 1, cscol - 1, cerow - 1, cecol)
                 if not parent or root == node or parent == node then
                     utils.update_selection(buf, node)

--- a/lua/wildfire/init.lua
+++ b/lua/wildfire/init.lua
@@ -1,7 +1,6 @@
 local api = vim.api
 
 local keymap = vim.keymap
-local ts_utils = require("nvim-treesitter.ts_utils")
 local parsers = require("nvim-treesitter.parsers")
 local utils = require("wildfire.utils")
 
@@ -102,7 +101,7 @@ local function init_by_node(node)
 end
 function M.init_selection()
     count = vim.v.count1
-    local node = ts_utils.get_node_at_cursor()
+    local node = vim.treesitter.get_node()
     if not node then
         return
     end
@@ -155,7 +154,9 @@ local function select_incremental(get_parent)
                 end
             end
             node = parent
-            local nsrow, nscol, nerow, necol = ts_utils.get_vim_range({ node:range() })
+            local nsrow, nscol, nerow, necol = vim.treesitter.get_node_range(node)
+            -- Convert 0-based to 1-based indexing to match vim coordinates
+            nsrow, nscol, nerow, necol = nsrow + 1, nscol + 1, nerow + 1, necol + 1
 
             local larger_range = utils.range_larger({ nsrow, nscol, nerow, necol }, { csrow, cscol, cerow, cecol })
 

--- a/lua/wildfire/utils.lua
+++ b/lua/wildfire/utils.lua
@@ -10,10 +10,12 @@ function M.get_range(node_or_range)
     else
         start_row, start_col, end_row, end_col = ts.get_node_range(node_or_range)
         -- Convert 0-based to 1-based indexing to match vim coordinates
+        -- Note: treesitter end_col is exclusive, but vim coordinates are inclusive
         start_row = start_row + 1
         start_col = start_col + 1
         end_row = end_row + 1
-        end_col = end_col + 1
+        -- end_col is already exclusive in treesitter (0-based), converting to 1-based inclusive means no change needed
+        -- because: 0-based exclusive position == 1-based inclusive position
     end
     return start_row, start_col, end_row, end_col ---@type integer, integer, integer, integer
 end
@@ -86,10 +88,12 @@ function M.update_selection(buf, node_or_range, selection_mode)
     else
         start_row, start_col, end_row, end_col = ts.get_node_range(node_or_range)
         -- Convert 0-based to 1-based indexing to match vim coordinates
+        -- Note: treesitter end_col is exclusive, but vim coordinates are inclusive
         start_row = start_row + 1
         start_col = start_col + 1
         end_row = end_row + 1
-        end_col = end_col + 1
+        -- end_col is already exclusive in treesitter (0-based), converting to 1-based inclusive means no change needed
+        -- because: 0-based exclusive position == 1-based inclusive position
     end
 
     local v_table = { charwise = "v", linewise = "V", blockwise = "<C-v>" }


### PR DESCRIPTION
This update modernizes the plugin **[`SUSTech-data/wildfire.nvim`](https://github.com/SUSTech-data/wildfire.nvim)** to ensure full compatibility with the latest `nvim-treesitter`, following its migration from the deprecated `master` branch to the new `main` branch and the removal of the `ts_utils` module.

### 🔧 Changes
- Removed dependency on the deprecated `nvim-treesitter.ts_utils` module  
- Replaced `ts_utils.get_node_at_cursor()` with `vim.treesitter.get_node()`  
- Replaced `ts_utils.get_vim_range()` with `vim.treesitter.get_node_range()`  
- Replaced `ts_utils.get_node_text()` with `vim.treesitter.get_node_text()`  
- Added proper coordinate conversion from 0-based to 1-based indexing  
- Ensured compatibility with modern `nvim-treesitter` and Neovim 0.10+

The legacy `master` branch remains available for users on older Neovim or `nvim-treesitter` versions.  
This `main` branch provides an updated, forward-compatible version for users who have migrated to the latest ecosystem.

---

### 💡 Suggestion for Maintainers — Create a `main` Branch

Since `nvim-treesitter` itself has transitioned to a `main` branch and deprecated legacy helpers, it would be helpful if this repository also provided a `main` branch for updated code.  
This would allow:
- `master` → legacy users (older Treesitter / Neovim)
- `main` → modern Treesitter API users

Maintainers can create a new `main` branch directly on GitHub using the "Branch" button, or via Git locally if preferred.  

Once the branch exists, this PR can be **retargeted from `master` → `main`** before merging.

---

### 📦 Temporary Installation for Users

Until the `main` branch is available upstream, users can install the updated fork directly with **Lazy.nvim**:
```lua
  {
    "Starslayerx/wildfire.nvim",
    branch = "main",
    event = "VeryLazy",
    dependencies = { "nvim-treesitter/nvim-treesitter" },
  }
```

This setup ensures both legacy and modern Neovim users can choose the version that best fits their environment — without breaking compatibility.

---

Thank you for maintaining **`SUSTech-data/wildfire.nvim`**.  
This PR aims to simplify the transition for users upgrading to modern Treesitter while keeping backward compatibility for existing setups.
