### PR TITLE
refactor: migrate to built-in treesitter API and extract surround module

### DIFF
--- a/lua/wildfire/init.lua
+++ b/lua/wildfire/init.lua
@@ -156,7 +156,9 @@ local function select_incremental(get_parent)
             node = parent
             local nsrow, nscol, nerow, necol = vim.treesitter.get_node_range(node)
             -- Convert 0-based to 1-based indexing to match vim coordinates
-            nsrow, nscol, nerow, necol = nsrow + 1, nscol + 1, nerow + 1, necol + 1
+            -- Note: treesitter end_col is exclusive, but vim coordinates are inclusive
+            nsrow, nscol, nerow, necol = nsrow + 1, nscol + 1, nerow + 1, necol
+            -- necol: 0-based exclusive == 1-based inclusive, so no +1 needed
 
             local larger_range = utils.range_larger({ nsrow, nscol, nerow, necol }, { csrow, cscol, cerow, cecol })
 

--- a/lua/wildfire/init.lua
+++ b/lua/wildfire/init.lua
@@ -1,7 +1,6 @@
 local api = vim.api
 
 local keymap = vim.keymap
-local parsers = require("nvim-treesitter.parsers")
 local utils = require("wildfire.utils")
 
 local M = {}
@@ -29,7 +28,24 @@ local count = 1
 function M.unsurround_coordinates(node_or_range, buf)
     -- local lines = vim.split(s, "\n")
     local srow, scol, erow, ecol = utils.get_range(node_or_range)
-    local lines = vim.api.nvim_buf_get_text(buf, srow - 1, scol - 1, erow - 1, ecol, {})
+
+    -- Validate buffer bounds to prevent index out of bounds error
+    local line_count = vim.api.nvim_buf_line_count(buf)
+    if srow < 1 or erow > line_count or srow > erow then
+        return false, { srow, scol, erow, ecol }
+    end
+
+    -- Validate column bounds for the specific lines
+    if scol < 1 or ecol < 0 then
+        return false, { srow, scol, erow, ecol }
+    end
+
+    -- Use pcall to safely get text, handle any edge cases
+    local ok, lines = pcall(vim.api.nvim_buf_get_text, buf, srow - 1, scol - 1, erow - 1, ecol, {})
+    if not ok or not lines or #lines == 0 then
+        return false, { srow, scol, erow, ecol }
+    end
+
     local node_text = table.concat(lines, "\n")
     local match_brackets = nil
     for _, pair in ipairs(M.options.surrounds) do
@@ -103,6 +119,15 @@ function M.init_selection()
     count = vim.v.count1
     local node = vim.treesitter.get_node()
     if not node then
+        -- No treesitter node available, try to handle gracefully
+        -- Check if treesitter is available for this filetype
+        local buf = api.nvim_get_current_buf()
+        local ok, parser = pcall(vim.treesitter.get_parser, buf)
+        if not ok or not parser then
+            -- No parser available for this filetype
+            vim.notify("Wildfire: No treesitter parser available for this filetype", vim.log.levels.WARN)
+            return
+        end
         return
     end
     init_by_node(node)
@@ -133,9 +158,21 @@ local function select_incremental(get_parent)
 
         -- Initialize incremental selection with current selection
         if not nodes or #nodes == 0 then
-            local root = parsers.get_parser():parse()[1]:root()
+            -- Use native vim.treesitter API to get the parser
+            local ok, parser = pcall(vim.treesitter.get_parser, buf)
+            if not ok or not parser then
+                -- No parser available for this filetype, fallback to visual selection
+                return
+            end
+            local tree = parser:parse()[1]
+            if not tree then
+                return
+            end
+            local root = tree:root()
             local node = root:named_descendant_for_range(csrow - 1, cscol - 1, cerow - 1, cecol)
-            update_selection_by_node(node)
+            if node then
+                update_selection_by_node(node)
+            end
             return
         end
 
@@ -146,7 +183,17 @@ local function select_incremental(get_parent)
             if not parent or parent == node then
                 -- Keep searching in the main tree
                 -- TODO: we should search on the parent tree of the current node.
-                local root = parsers.get_parser():parse()[1]:root()
+                local ok, parser = pcall(vim.treesitter.get_parser, buf)
+                if not ok or not parser then
+                    utils.update_selection(buf, node)
+                    return
+                end
+                local tree = parser:parse()[1]
+                if not tree then
+                    utils.update_selection(buf, node)
+                    return
+                end
+                local root = tree:root()
                 parent = root:named_descendant_for_range(csrow - 1, cscol - 1, cerow - 1, cecol)
                 if not parent or root == node or parent == node then
                     utils.update_selection(buf, node)

--- a/lua/wildfire/init.lua
+++ b/lua/wildfire/init.lua
@@ -1,7 +1,6 @@
 local api = vim.api
 
 local keymap = vim.keymap
-local ts_utils = require("nvim-treesitter.ts_utils")
 local parsers = require("nvim-treesitter.parsers")
 local utils = require("wildfire.utils")
 
@@ -102,7 +101,7 @@ local function init_by_node(node)
 end
 function M.init_selection()
     count = vim.v.count1
-    local node = ts_utils.get_node_at_cursor()
+    local node = vim.treesitter.get_node()
     if not node then
         return
     end
@@ -155,7 +154,9 @@ local function select_incremental(get_parent)
                 end
             end
             node = parent
-            local nsrow, nscol, nerow, necol = ts_utils.get_vim_range({ node:range() })
+            local nsrow, nscol, nerow, necol = vim.treesitter.get_node_range(node)
+            -- Convert 0-based to 1-based indexing to match vim coordinates
+            nsrow, nscol, nerow, necol = nsrow + 1, nscol + 1, nerow + 1, necol + 1
 
             local larger_range = utils.range_larger({ nsrow, nscol, nerow, necol }, { csrow, cscol, cerow, cecol })
 

--- a/lua/wildfire/utils.lua
+++ b/lua/wildfire/utils.lua
@@ -10,10 +10,12 @@ function M.get_range(node_or_range)
     else
         start_row, start_col, end_row, end_col = ts.get_node_range(node_or_range)
         -- Convert 0-based to 1-based indexing to match vim coordinates
+        -- Note: treesitter end_col is exclusive, but vim coordinates are inclusive
         start_row = start_row + 1
         start_col = start_col + 1
         end_row = end_row + 1
-        end_col = end_col + 1
+        -- end_col is already exclusive in treesitter (0-based), converting to 1-based inclusive means no change needed
+        -- because: 0-based exclusive position == 1-based inclusive position
     end
     return start_row, start_col, end_row, end_col ---@type integer, integer, integer, integer
 end
@@ -86,10 +88,12 @@ function M.update_selection(buf, node_or_range, selection_mode)
     else
         start_row, start_col, end_row, end_col = ts.get_node_range(node_or_range)
         -- Convert 0-based to 1-based indexing to match vim coordinates
+        -- Note: treesitter end_col is exclusive, but vim coordinates are inclusive
         start_row = start_row + 1
         start_col = start_col + 1
         end_row = end_row + 1
-        end_col = end_col + 1
+        -- end_col is already exclusive in treesitter (0-based), converting to 1-based inclusive means no change needed
+        -- because: 0-based exclusive position == 1-based inclusive position
     end
 
     local v_table = { charwise = "v", linewise = "V", blockwise = "<C-v>" }


### PR DESCRIPTION
## Summary

- Remove `nvim-treesitter` dependency, migrate to built-in `vim.treesitter` API
- Extract surround detection into `surround.lua` using TS node structure (anonymous children as delimiters) instead of text-based regex matching
- Fix selection expansion across injected language trees (e.g. JS inside HTML)
- Add bounds checking and coordinate conversion fixes

## State Protocol: Pluggable Checkpoint

Current selection state is managed by two module-level tables:

```
selections[buf]  -- stack of selections (TSNode | {srow,scol,erow,ecol})
nodes_all[buf]   -- stack of TSNode references
```

This works but couples the state representation tightly to the expansion algorithm. With [neovim/neovim@72d3a57](https://github.com/neovim/neovim/commit/72d3a57f270fdca5e592dcf2e4b7c3b00549c05e) landing built-in `vim.treesitter._select` (providing `an`/`in`/`]n`/`[n` default mappings), Neovim will ship its own incremental selection with its own history/checkpoint mechanism.

To prepare for this, the next step is to define a **checkpoint protocol** — an interface that decouples "what to remember" from "how to remember it":

```lua
---@class wildfire.Checkpoint
---@field save fun(self, buf: integer, node: TSNode, range: table)
---@field restore fun(self, buf: integer): TSNode|table|nil
---@field reset fun(self, buf: integer)
---@field current fun(self, buf: integer): TSNode|table|nil
```

This allows swapping the backing implementation:
- **Built-in backend** — delegate to `vim.treesitter._select` history when available (Neovim nightly+)
- **Custom backend** — current stack-based approach as fallback for stable Neovim

With this separation, wildfire's unique value (surround-aware inner selection) becomes a thin layer on top of whichever checkpoint backend is active, rather than reimplementing the full node traversal + injection handling that Neovim now ships.

## Test plan

- [ ] `<CR>` on cursor starts selection at TS node under cursor
- [ ] Repeated `<CR>` expands through parent nodes, selecting inner content first for surround nodes (`()`, `{}`, `[]`, `<>`)
- [ ] `<BS>` shrinks back to previous selection
- [ ] Count prefix works (`3<CR>` jumps 3 levels)
- [ ] Selection crosses injected language boundaries (e.g. `<script>` in HTML)
- [ ] Empty surrounds (`()`, `{}`) are handled without error
- [ ] No `nvim-treesitter` required at runtime